### PR TITLE
fix: change action name to 'Setup Goose CLI' for marketplace uniqueness

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Setup Goose'
+name: 'Setup Goose CLI'
 description: 'Install and cache Goose AI agent for GitHub Actions workflows'
 author: 'Hugues Clouâtre'
 


### PR DESCRIPTION
## Problem

GitHub Marketplace rejected the action name `Setup Goose` with error:
> Name must be unique. Cannot match an existing action, user or organization name.

## Solution

Changed action name to **`Setup Goose CLI`**

## Rationale

- More specific (identifies it as the CLI tool)
- Avoids conflicts with potential 'Goose' user/org names
- Follows industry patterns (Setup Node CLI, Setup Python CLI)
- Still clear and professional

## Changes

- action.yml: `name: 'Setup Goose'` → `name: 'Setup Goose CLI'`

---

**Type:** Bug fix
**Scope:** Marketplace publication requirement
**Breaking:** No (users reference by repo, not action name)