### PR TITLE
fix: change action name to 'Setup Goose CLI' for marketplace uniqueness

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Setup Goose'
+name: 'Setup Goose CLI'
 description: 'Install and cache Goose AI agent for GitHub Actions workflows'
 author: 'Hugues Clouâtre'
 


### PR DESCRIPTION
## Problem

GitHub Marketplace rejected the action name `Setup Goose` with error:
> Name must be unique. Cannot match an existing action, user or organization name.

**Root cause:** `mscno/setup-goose` exists (installs Pressly's database migration tool), causing a name collision even though they're completely different tools:
- **Their Goose:** Database migration tool (pressly/goose)
- **Our Goose:** AI agent for developers (block/goose)

## Solution

Changed action name to **`Setup Goose CLI`**

## Rationale

- **Follows industry pattern:** Matches `Setup Sentry CLI`, `Setup Arduino CLI`
- **Technically accurate:** We install the CLI binary from block/goose releases
- **Marketplace available:** No collision detected at `github.com/marketplace/actions/setup-goose-cli`
- **Professional and concise:** Clear, follows conventions

## Changes

- `action.yml` line 1: `name: 'Setup Goose'` → `name: 'Setup Goose CLI'`

## Breaking Changes

**None.** Users reference actions by repository (`clouatre-labs/setup-goose-action@v1`), not by action name. The action name only affects:
- Marketplace listing title
- Action metadata

Existing workflows will continue to work without modification.

## Next Steps

After merge:
1. Create release v1.0.3 with this change
2. Update v1 tag to v1.0.3
3. Publish to GitHub Marketplace

---

**Type:** Bug fix  
**Scope:** Marketplace publication requirement  
**Risk:** None (metadata-only change)