### PR TITLE
feat: Add GitHub Marketplace badge and production-ready examples for v1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ This action uses **independent versioning** from Goose itself.
 
 ## Prerequisites
 
-Before using this action, configure a secret for your AI provider:
+1. **Get an API key** from your chosen provider: [Supported Providers](https://block.github.io/goose/docs/getting-started/providers/)
 
-1. Go to **Settings → Secrets and variables → Actions** in your repository
-2. Click **New repository secret**
-3. Add your API key:
-   - **Google:** `GOOGLE_API_KEY`
-   - **OpenAI:** `OPENAI_API_KEY`
-   - **Anthropic:** `ANTHROPIC_API_KEY`
+2. **Add it as a repository secret:**
+   - Go to **Settings → Secrets and variables → Actions**
+   - Click **New repository secret**
+   - Name it (e.g., `GEMINI_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`)
+
+3. **Configure in your workflow** - map your secret to Goose's expected environment variable (see examples below)
 
 ## Quick Start
 


### PR DESCRIPTION
## Overview

Updates README for GitHub Marketplace release (v1.0.3) with tested, production-ready examples.

## Changes

### Added
- GitHub Marketplace badge and link
- Prerequisites section explaining API key setup
- Quick Start example: Simple AI code review workflow
- Advanced example: PR comment posting workflow

### Fixed
- **CRITICAL**: Removed non-existent `--diff-file` flag (doesn't exist in Goose v1.14.0)
- Use correct `--instructions` flag for passing files to goose run
- YAML config now uses heredoc for proper multi-line formatting (not `\n` strings)
- File-based output approach (more reliable than heredoc in $GITHUB_OUTPUT)
- Added `--no-session` and `--quiet` flags for cleaner CI output
- Error handling for empty diffs

## Testing

All examples tested in Docker with Goose v1.14.0:

✅ YAML heredoc configuration works  
✅ All command flags validated (`--instructions`, `--no-session`, `--quiet`)  
✅ Instruction file approach confirmed working  
✅ File-based output method validated  
✅ Empty diff detection logic tested  
✅ Command reaches Google API (tested with fake key - got expected 400)

See test artifacts in `test-docker/` directory (not included in PR).

## Breaking Changes

None - only documentation updates.

## Related Issues

Preparation for v1.0.3 GitHub Marketplace release.

## Checklist

- [x] Examples tested in Docker environment
- [x] All command flags verified against Goose v1.14.0
- [x] YAML syntax validated
- [x] GitHub Actions best practices followed
- [x] No emojis in documentation
- [x] Commit message follows conventional commits