### PR TITLE
refactor: add binary info to verification output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,8 @@ runs:
       run: |
         echo "::group::Verifying Goose installation"
         goose --version
+        echo "Installed binary:"
+        ls -lh ~/.local/bin/goose
         echo "::endgroup::"
 
 branding:


### PR DESCRIPTION
## Changes
Shows installed binary size and permissions in verification step.

## Example Output
```
Verifying Goose installation
goose version 1.14.0
Installed binary:
-rwxr-xr-x  1 runner  staff  45M Nov 15 13:00 /home/runner/.local/bin/goose
```

## Benefits
- ✅ Helps debug download issues (shows file size)
- ✅ Helps debug execution issues (shows permissions)
- ✅ Aligns with setup-q-cli-action pattern

## Impact
- **Files changed:** 1 (action.yml)
- **Lines added:** 2
- **Risk:** Zero (only adds output)