### PR TITLE
Add automated version management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -1,0 +1,76 @@
+name: Check for New Version
+on:
+  schedule:
+    - cron: '0 9 * * MON'  # Every Monday 9am UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-version:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get versions
+        id: versions
+        run: |
+          set -euo pipefail
+          
+          # Get latest release from block/goose
+          LATEST=$(gh api repos/block/goose/releases/latest --jq '.tag_name' | sed 's/^v//')
+          CURRENT=$(yq '.inputs.version.default' action.yml)
+          
+          echo "latest=$LATEST" >> $GITHUB_OUTPUT
+          echo "current=$CURRENT" >> $GITHUB_OUTPUT
+          echo "needs_update=$([[ "$LATEST" != "$CURRENT" ]] && echo true || echo false)" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Update version
+        if: steps.versions.outputs.needs_update == 'true'
+        run: |
+          set -euo pipefail
+          
+          LATEST="${{ steps.versions.outputs.latest }}"
+          CURRENT="${{ steps.versions.outputs.current }}"
+          
+          # Update action.yml
+          yq -i ".inputs.version.default = \"$LATEST\"" action.yml
+          
+          # Verify update
+          UPDATED_ACTION=$(yq '.inputs.version.default' action.yml)
+          if [[ "$UPDATED_ACTION" != "$LATEST" ]]; then
+            echo "Error: action.yml update failed. Expected $LATEST, got $UPDATED_ACTION"
+            exit 1
+          fi
+          
+          # Create PR
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b update-version-${LATEST}
+          git add action.yml
+          git commit -m "chore: update default version to ${LATEST}"
+          git push origin update-version-${LATEST}
+          
+          gh pr create \
+            --title "Update default version to ${LATEST}" \
+            --body "## New Release Detected
+          
+          **Previous version:** ${CURRENT}
+          **New version:** ${LATEST}
+          
+          **Release notes:** https://github.com/block/goose/releases/tag/v${LATEST}
+          
+          ### Changes
+          - Updates default version in \`action.yml\`
+          - README automatically reflects new version (links to action.yml)
+          - Cache keys will automatically use new version
+          - Users without explicit version will get ${LATEST}
+          
+          **Note:** Users with pinned versions are unaffected." \
+            --label "dependencies"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Implements automated weekly version checks and PR creation for Goose updates.

## Changes

- **Workflow**: `.github/workflows/check-version.yml`
  - Runs every Monday at 9am UTC
  - Checks for new Goose releases from `block/goose`
  - Auto-creates PR if new version found
  - Manual trigger available via `workflow_dispatch`

- **Dependabot**: `.github/dependabot.yml`
  - Weekly updates for GitHub Actions dependencies
  - Auto-creates PRs for `actions/checkout`, `actions/cache`, etc.

## Testing

- ✅ YAML syntax validated
- ✅ GitHub API calls tested (`gh api repos/block/goose/releases/latest`)
- ✅ `yq` commands tested (version extraction/update)
- ⏳ Workflow execution pending (will test after merge)

## Notes

- README already references action.yml for default version (no manual updates needed)
- Only action.yml requires updating (simpler than setup-q-cli-action)

## Related

- setup-q-cli-action: PR #6 (merged, tested, working)
- Phase 2 automation complete for both repos