### PR TITLE
chore: simplify pipx usage and remove redundant example

### DIFF
--- a/.github/workflows/test-tier1.yml
+++ b/.github/workflows/test-tier1.yml
@@ -17,9 +17,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Lint Code
-        run: |
-          pipx install uv
-          uv tool run ruff check --output-format=json . > lint.json || true
+        run: pipx run ruff check --output-format=json . > lint.json || true
 
       - uses: clouatre-labs/setup-goose-action@v1
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Lint Code
-        run: |
-          pipx install uv
-          uv tool run ruff check --output-format=json . > lint-results.json || true
+        run: pipx run ruff check --output-format=json . > lint-results.json || true
 
       - name: Setup Goose CLI
         uses: clouatre-labs/setup-goose-action@v1
@@ -114,49 +112,6 @@ jobs:
 | `goose-path` | Path to Goose binary directory |
 
 ## Examples
-
-### Security Scan with Artifact Upload
-
-```yaml
-name: Security Scan
-on: [push]
-
-permissions:
-  contents: read
-
-jobs:
-  scan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      
-      - name: Run Security Scanner
-        run: |
-          pipx install uv
-          uv tool run ruff check --select S --output-format=json . > security.json || true
-      
-      - uses: clouatre-labs/setup-goose-action@v1
-      
-      - name: AI Analysis
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          mkdir -p ~/.config/goose
-          cat > ~/.config/goose/config.yaml << 'EOF'
-          GOOSE_PROVIDER: anthropic
-          GOOSE_MODEL: claude-haiku-4-5-20251001
-          keyring: false
-          EOF
-          
-          echo "Summarize security findings:" > prompt.txt
-          cat security.json >> prompt.txt
-          goose run --instructions prompt.txt --no-session --quiet > report.md
-      
-      - uses: actions/upload-artifact@v5
-        with:
-          name: security-report
-          path: report.md
-```
 
 ### Pin to Specific Version
 

--- a/examples/tier1-maximum-security.yml
+++ b/examples/tier1-maximum-security.yml
@@ -12,9 +12,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Lint Code
-        run: |
-          pipx install uv
-          uv tool run ruff check --output-format=json . > lint.json || true
+        run: pipx run ruff check --output-format=json . > lint.json || true
 
       - name: Setup Goose CLI
         uses: clouatre-labs/setup-goose-action@v1


### PR DESCRIPTION
## Summary

Simplifies linting commands by using pre-installed pipx directly, and removes redundant Security Scan example.

## Changes

### Simplified pipx usage (3 locations)
**Before:**
```yaml
run: |
  pipx install uv
  uv tool run ruff check --output-format=json . > lint.json || true
```

**After:**
```yaml
run: pipx run ruff check --output-format=json . > lint.json || true
```

**Updated in:**
- `.github/workflows/test-tier1.yml`
- `README.md` (Quick Start)
- `examples/tier1-maximum-security.yml`

### Removed redundant example
- Removed "Security Scan with Artifact Upload" example from README
- Same pattern as Quick Start, just different AI provider
- Reduces documentation duplication

## Why

- **Faster**: No intermediate `uv` installation needed
- **Simpler**: Single line instead of 3
- **Pre-installed**: Uses pipx 1.8.0 bundled with Ubuntu 24.04 runners
- **Cleaner docs**: Removes redundant example that doesn't add educational value

## Testing

- ✅ Verified pipx 1.8.0 is pre-installed on Ubuntu 24.04 runners
- ✅ Tested `pipx run ruff` works locally
- ✅ No functional changes, only simplification