### PR TITLE
chore(docs): bump actions/checkout to v6 in README and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Lint Code
         run: pipx run ruff check --output-format=json . > lint-results.json || true

--- a/examples/tier1-maximum-security.yml
+++ b/examples/tier1-maximum-security.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Lint Code
         run: pipx run ruff check --output-format=json . > lint.json || true

--- a/examples/tier2-balanced-security.yml
+++ b/examples/tier2-balanced-security.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/examples/tier3-advanced-patterns.yml
+++ b/examples/tier3-advanced-patterns.yml
@@ -12,7 +12,7 @@ jobs:
       github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Updates documentation to use actions/checkout v6, matching the dependency update in #20.

### Changes
- `README.md`: v5 -> v6
- `examples/tier1-maximum-security.yml`: v5 -> v6
- `examples/tier2-balanced-security.yml`: v5 -> v6
- `examples/tier3-advanced-patterns.yml`: v5 -> v6