### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -12,7 +12,7 @@ jobs:
   check-version:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Get versions
         id: versions

--- a/.github/workflows/test-tier1.yml
+++ b/.github/workflows/test-tier1.yml
@@ -14,7 +14,7 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Lint Code
         run: pipx run ruff check --output-format=json . > lint.json || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Test action
         uses: ./
@@ -40,7 +40,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Test action
         uses: ./
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: First run (cache miss)
         uses: ./
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Test older version
         uses: ./

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Lint Code
         run: pipx run ruff check --output-format=json . > lint-results.json || true

--- a/examples/tier1-maximum-security.yml
+++ b/examples/tier1-maximum-security.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Lint Code
         run: pipx run ruff check --output-format=json . > lint.json || true

--- a/examples/tier2-balanced-security.yml
+++ b/examples/tier2-balanced-security.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/examples/tier3-advanced-patterns.yml
+++ b/examples/tier3-advanced-patterns.yml
@@ -12,7 +12,7 @@ jobs:
       github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Updates

- `actions/checkout@v5` → `v6`

## Verification

All updates verified via Context7 docs and GitHub releases:
- checkout@v6: No breaking changes for our use case (credential persistence change only affects Docker container actions)

## Testing

- [ ] Test workflow passes
- [ ] All example workflows validated