### PR TITLE
fix: handle existing branch in version check workflow

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -36,6 +36,20 @@ jobs:
           
           LATEST="${{ steps.versions.outputs.latest }}"
           CURRENT="${{ steps.versions.outputs.current }}"
+          BRANCH_NAME="update-version-${LATEST}"
+          
+          # Check if PR already exists for this version
+          EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number // empty')
+          if [[ -n "$EXISTING_PR" ]]; then
+            echo "PR #$EXISTING_PR already exists for $BRANCH_NAME, skipping"
+            exit 0
+          fi
+          
+          # Delete orphan branch if exists (branch without PR)
+          if git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null 2>&1; then
+            echo "Deleting orphan branch $BRANCH_NAME (no PR exists)"
+            gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$BRANCH_NAME"
+          fi
           
           # Update action.yml
           yq -i ".inputs.version.default = \"$LATEST\"" action.yml


### PR DESCRIPTION
## Problem

The `Check for New Version` workflow fails when the target branch already exists from a previous run that didn't complete successfully (orphan branch).

**Root cause:** The workflow doesn't check if the branch already exists before attempting to push.

## Solution

Added checks before creating branch/PR:
1. **Skip if PR already exists** - Uses `gh pr list --head` to check for existing PR
2. **Delete orphan branch** - If branch exists without a PR, delete it before proceeding

This makes the workflow idempotent and self-healing.

## Testing

- Deleted orphan branch `update-version-1.15.0` that was blocking the workflow
- Will trigger workflow manually after merge to verify fix