### PR TITLE
feat: add Renovate config for automated version updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^action\\.yml$"],
+      "matchStrings": [
+        "default:\\s*['\"](?<currentValue>\\d+\\.\\d+\\.\\d+)['\"]"
+      ],
+      "depNameTemplate": "block/goose",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
+  ]
+}


### PR DESCRIPTION
Adds Renovate configuration to automate Goose version updates.

**Problem**: Custom `check-version.yml` workflow uses `yq` which rewrites YAML and removes formatting (blank lines).

**Solution**: Use Renovate with regex manager to preserve file formatting.

**Changes**:
- Added `renovate.json` with custom regex manager
- Tracks `block/goose` GitHub releases
- Matches version in `action.yml` default field
- Preserves YAML formatting (no rewrite)

**Next steps**:
1. Install Renovate GitHub App on repo
2. Test Renovate creates proper PRs
3. Remove `check-version.yml` workflow (separate PR)

**Benefits**:
- Formatting preservation
- Automatic changelogs
- Better ecosystem
- Less maintenance