### PR TITLE
chore: enable automerge for patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,5 +12,11 @@
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"
     }
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
Configures Renovate to automerge patch version updates.

**Change:** Add `packageRules` to automerge only patch updates (e.g., 1.15.0 -> 1.15.1)

Minor and major updates still require manual review.