### PR TITLE
chore: disable dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
+  "dependencyDashboard": false,
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Disables Renovate Dependency Dashboard issue.

**Why:** Unnecessary for small projects with automerge enabled.