### PR TITLE
docs: simplify versioning, update test to 1.15.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 env:
-  DEFAULT_GOOSE_VERSION: '1.14.0'
+  DEFAULT_GOOSE_VERSION: '1.15.0'
 
 jobs:
   test-ubuntu:

--- a/README.md
+++ b/README.md
@@ -9,19 +9,7 @@ GitHub Action to install and cache [Goose AI agent](https://github.com/block/goo
 
 **Available on the [GitHub Marketplace](https://github.com/marketplace/actions/setup-goose-cli)**
 
-## Versioning
-
-This action uses **independent versioning** from Goose itself.
-
-### Version Compatibility
-
-| Action Version | Default Goose Version | Release Date |
-|---------------|----------------------|--------------|
-| v1.0.3 | 1.14.0 | 2025-11-13 |
-| v1.0.1 | 1.14.0 | 2025-11-12 |
-| v1.0.0 | 1.12.1 | 2025-11-06 |
-
-### Recommended Usage
+## Usage
 
 ```yaml
 # Recommended: Get latest v1.x updates automatically


### PR DESCRIPTION
- Remove version table from README (Renovate updates action.yml automatically)
- Update test workflow to use Goose 1.15.0