### PR TITLE
ci: remove macOS support to reduce CI costs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,24 +45,6 @@ jobs:
           which goose
           goose --help
 
-  test-macos:
-    name: Test on macOS
-    if: github.event_name == 'push' || github.event.pull_request.draft == false || github.event_name == 'merge_group'
-    runs-on: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-
-      - name: Test action
-        uses: ./
-        with:
-          version: ${{ env.DEFAULT_GOOSE_VERSION }}
-
-      - name: Verify installation
-        run: |
-          goose --version
-          which goose
-
   test-cache:
     name: Test caching
     if: github.event_name == 'push' || github.event.pull_request.draft == false || github.event_name == 'merge_group'

--- a/README.md
+++ b/README.md
@@ -133,18 +133,18 @@ Read the full explanation: [AI-Augmented CI/CD blog post](https://clouatre.ca/po
 
 - **Caching**: Automatically caches Goose binary for faster subsequent runs
 - **Version Pinning**: Install specific Goose versions for reproducible builds
-- **Cross-Platform**: Supports Linux (x64, arm64) and macOS (x64, arm64)
 - **Lightweight**: Composite action with no external dependencies
 
 ## Supported Platforms
 
 | OS | Architecture | Status |
 |----|--------------|--------|
-| Ubuntu | x64 | ✅ Supported |
-| Ubuntu | arm64 | ✅ Supported |
-| macOS | x64 | ✅ Supported |
-| macOS | arm64 | ✅ Supported |
-| Windows | - | ❌ Not supported |
+| Ubuntu | x64 | Supported |
+| Ubuntu | arm64 | Supported |
+| macOS | - | Not supported |
+| Windows | - | Not supported |
+
+> **Note:** This action only supports Linux runners. macOS runners have a 10x billing multiplier on GitHub Actions, and there's no practical use case for running Goose on macOS in CI (Goose executes prompts and tool calls, nothing platform-specific).
 
 ## How It Works
 

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,14 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Check platform
+      shell: bash
+      run: |
+        if [ "${{ runner.os }}" != "Linux" ]; then
+          echo "::error::This action only supports Linux runners. Current OS: ${{ runner.os }}"
+          exit 1
+        fi
+
     - name: Cache Goose binary
       id: cache-goose
       uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5
@@ -52,19 +60,8 @@ runs:
           exit 1
         fi
         
-        # Determine OS
-        OS="${{ runner.os }}"
-        if [ "$OS" = "Linux" ]; then
-          GOOSE_OS="unknown-linux-gnu"
-        elif [ "$OS" = "macOS" ]; then
-          GOOSE_OS="apple-darwin"
-        else
-          echo "::error::Unsupported OS: $OS"
-          exit 1
-        fi
-        
         # Download and extract
-        DOWNLOAD_URL="https://github.com/block/goose/releases/download/v${{ inputs.version }}/goose-${GOOSE_ARCH}-${GOOSE_OS}.tar.bz2"
+        DOWNLOAD_URL="https://github.com/block/goose/releases/download/v${{ inputs.version }}/goose-${GOOSE_ARCH}-unknown-linux-gnu.tar.bz2"
         echo "Downloading from: $DOWNLOAD_URL"
         
         curl -fsSL "$DOWNLOAD_URL" | tar -xj -C ~/.local/bin


### PR DESCRIPTION
## Summary

Removes macOS support from this action entirely.

## BREAKING CHANGE

This action now only supports Linux runners. Attempting to use it on macOS will fail with a clear error message.

## Why

- macOS runners have a **10x billing multiplier** on GitHub Actions
- No practical use case for running Goose on macOS in CI
- Goose executes prompts and tool calls - nothing platform-specific
- **Saves approximately 450 equivalent GitHub Actions minutes per month**

## Changes

- `action.yml`: Remove macOS platform detection, add explicit Linux-only check
- `.github/workflows/test.yml`: Remove `test-macos` job
- `README.md`: Update supported platforms table, add note about Linux-only support

## Migration

If you were using this action on macOS runners (unlikely), switch to Linux runners:

```yaml
# Before
runs-on: macos-latest

# After
runs-on: ubuntu-latest
```