### PR TITLE
chore: align renovate config with aptu repo format

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:best-practices"
-  ],
+  "extends": ["config:best-practices"],
+  "labels": ["dependencies"],
   "platformAutomerge": true,
-  "labels": [
-    "dependencies"
-  ],
-  "dependencyDashboard": false,
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": [
-        "^action\\.yml$"
-      ],
+      "fileMatch": ["^action\\.yml$"],
       "matchStrings": [
         "default:\\s*['\"](?<currentValue>\\d+\\.\\d+\\.\\d+)['\"]"
       ],
@@ -24,15 +17,11 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": [
-        "patch"
-      ],
+      "matchUpdateTypes": ["patch"],
       "automerge": true
     },
     {
-      "matchManagers": [
-        "github-actions"
-      ],
+      "matchManagers": ["github-actions"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
## Summary

Aligns renovate.json formatting and structure with the aptu repo configuration.

## Changes

- Remove `dependencyDashboard: false` (not in aptu config)
- Clean up JSON formatting to match aptu's compact style
- Preserve all auto-merge functionality (no behavior changes)

## Testing

- [x] Configuration is valid JSON
- [x] All existing auto-merge rules preserved