### PR TITLE
fix: ensure goose-version output is set on cache hits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
 outputs:
   goose-version:
     description: 'Installed Goose version'
-    value: ${{ steps.install.outputs.version }}
+    value: ${{ inputs.version }}
   goose-path:
     description: 'Path to Goose binary directory'
     value: ${{ steps.setup-path.outputs.path }}
@@ -67,7 +67,6 @@ runs:
         curl -fsSL "$DOWNLOAD_URL" | tar -xj -C ~/.local/bin
         chmod +x ~/.local/bin/goose
         
-        echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
         echo "::endgroup::"
 
     - name: Setup PATH


### PR DESCRIPTION
Closes #50

## Summary

The goose-version output was only set during the install step, which is skipped when the cache hits. This caused the output to be empty on cache hits, breaking workflows that depend on this output value.

This fix maps the output directly from inputs.version instead of relying on a conditional step. This is the idiomatic approach for composite actions when exposing an input as an output without transformation.

## Changes

- Updated outputs.goose-version.value to map directly from inputs.version
- Removed redundant version output logic from the install step
- The version output is now guaranteed to be available regardless of cache status

## Testing

- Verified goose-version output is set on cache miss (install step runs)
- Verified goose-version output is set on cache hit (install step skipped)
- Verified version value matches inputs.version in both scenarios
- YAML syntax validation passes

---
- [x] Tests pass locally
- [x] Linter clean
- [x] No breaking changes