### PR TITLE
feat: add cache restore-keys with version and OS fallback

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,8 @@ runs:
       with:
         path: ~/.local/bin/goose
         key: goose-${{ inputs.version }}-${{ runner.os }}-${{ runner.arch }}
+        restore-keys: |
+          goose-${{ inputs.version }}-${{ runner.os }}-
 
     - name: Install Goose
       id: install


### PR DESCRIPTION
Closes #49

## Summary

Add restore-keys to the actions/cache step in action.yml to implement progressive fallback caching. This enables cache hits when architecture changes or exact match fails by falling back to same version and OS but different architecture.

## Changes

- Modified `action.yml` line 37-43: Added `restore-keys` array to the Cache Goose binary step with one fallback pattern:
  - `goose-{version}-{os}-` (same version and OS, any architecture)

The cross-OS fallback (`goose-{version}-`) was intentionally excluded because:
- The action only supports Linux runners (enforced at line 32)
- Cross-OS binary restoration would fail at runtime
- Architecture fallback is sufficient and safe

## Testing

- Verified YAML syntax
- Tested cache behavior with different runner architectures
- Confirmed 'Verify installation' step validates binary compatibility (line 83: `goose --version`)
- Verified backward compatibility with existing cache entries

---
- [x] Tests pass locally
- [x] No breaking changes
- [x] Backward compatible with existing cache