### PR TITLE
docs: document checksum verification limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ jobs:
 
 **Unsafe Pattern:** AI analyzes git diffs directly → vulnerable to prompt injection.
 
+**Checksum Verification:** Checksum verification is not available for this action because the upstream [block/goose](https://github.com/block/goose) project does not publish checksums or cryptographic attestations with releases. See [block/goose#5994](https://github.com/block/goose/issues/5994) for SLSA attestations tracking.
+
 See [SECURITY.md](SECURITY.md) for reporting vulnerabilities.
 
 ## Security Patterns


### PR DESCRIPTION
Closes #56

## Summary

Documents that checksum verification is not currently possible because block/goose does not publish checksums or attestations with releases.

## Changes

- Added security note to README explaining limitation
- Referenced upstream issue block/goose#5994 for SLSA attestations

## Testing

- [x] Documentation is clear and accurate
- [x] Links are valid
- [x] No breaking changes