### PR TITLE
chore(renovate): automerge minor dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["patch"],
+      "matchUpdateTypes": ["patch", "minor"],
       "automerge": true
     },
     {


### PR DESCRIPTION
Add `minor` to the automerge rule alongside `patch`. Major updates remain manual for review.

CI status checks still gate all merges before automerge completes.

## Changes

- `renovate.json`: `matchUpdateTypes` expanded from `["patch"]` to `["patch", "minor"]`

## Safety

- Branch protection + merge queue with required status checks gate broken updates
- `config:best-practices` ensures SHA pinning for supply chain security
- Major bumps still require manual review

## Context

Matches the automerge strategy used in sibling repos (e.g. setup-q-cli-action). Once merged, PR #77 (goose v1.23.2 minor bump) should be automerged by Renovate on its next run.