### PR TITLE
chore(renovate): migrate fileMatch to managerFilePatterns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^action\\.yml$"],
+      "managerFilePatterns": ["/^action\\.yml$/"],
       "matchStrings": [
         "default:\\s*['\"](?<currentValue>\\d+\\.\\d+\\.\\d+)['\"]"
       ],


### PR DESCRIPTION
Migrate the deprecated `fileMatch` option to `managerFilePatterns` in our custom regex manager.

`fileMatch` (regex-only) has been replaced by `managerFilePatterns` (supports both regex and glob). Renovate auto-migrates existing configs, but this makes the intent explicit and uses the slash-delimited regex syntax.

**Change:** `"fileMatch": ["^action\\.yml$"]` -> `"managerFilePatterns": ["/^action\\.yml$/"]`

Ref: https://docs.renovatebot.com/configuration-options/#managerfilepatterns