### PR TITLE
chore(renovate): disable dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,5 +24,6 @@
       "matchManagers": ["github-actions"],
       "automerge": true
     }
-  ]
+  ],
+  "dependencyDashboard": false
 }


### PR DESCRIPTION
Align with setup-kiro-action and setup-q-cli-action by disabling the dependency dashboard.

Both sibling repos already have `dependencyDashboard: false` set.