### PR TITLE
chore(ci): pin ubuntu runner and group renovate updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
   test-ubuntu:
     name: Test on Ubuntu
     if: github.event_name == 'push' || github.event.pull_request.draft == false || github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -49,7 +49,7 @@ jobs:
   test-cache:
     name: Test caching
     if: github.event_name == 'push' || github.event.pull_request.draft == false || github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -92,7 +92,7 @@ jobs:
   test-version:
     name: Test different version
     if: github.event_name == 'push' || github.event.pull_request.draft == false || github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -110,7 +110,7 @@ jobs:
   test-check-latest:
     name: Test check-latest input
     if: github.event_name == 'push' || github.event.pull_request.draft == false || github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
   "labels": ["dependencies"],
+  "minimumReleaseAge": "3 days",
   "platformAutomerge": true,
+  "dependencyDashboard": false,
+  "schedule": ["before 6am on monday"],
   "customManagers": [
     {
       "customType": "regex",
@@ -17,13 +20,16 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true
+      "groupName": "non-major",
+      "matchUpdateTypes": ["patch", "minor", "digest", "pin", "lockFileMaintenance"],
+      "automerge": true,
+      "platformAutomerge": true
     },
     {
+      "groupName": "github-actions",
       "matchManagers": ["github-actions"],
-      "automerge": true
+      "automerge": true,
+      "platformAutomerge": true
     }
-  ],
-  "dependencyDashboard": false
+  ]
 }


### PR DESCRIPTION
Pins ubuntu-latest to ubuntu-24.04 for deterministic builds. Groups Renovate patch/minor/digest into single weekly PR to minimize CI runs.