### PR TITLE
fix: update goose repo references from block/goose to aaif-goose/goose

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   # renovate: datasource=github-releases depName=aaif-goose/goose extractVersion=^v(?<version>.*)$
-  DEFAULT_GOOSE_VERSION: '1.20.1'
+  DEFAULT_GOOSE_VERSION: '1.30.0'
 
 jobs:
   test-ubuntu:
@@ -108,7 +108,7 @@ jobs:
       - name: Test older version
         uses: ./
         with:
-          version: '1.20.1'
+          version: '1.30.0'
 
       - name: Verify correct version
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   # renovate: datasource=github-releases depName=aaif-goose/goose extractVersion=^v(?<version>.*)$
-  DEFAULT_GOOSE_VERSION: '1.15.0'
+  DEFAULT_GOOSE_VERSION: '1.20.1'
 
 jobs:
   test-ubuntu:
@@ -108,7 +108,7 @@ jobs:
       - name: Test older version
         uses: ./
         with:
-          version: '1.11.0'
+          version: '1.20.1'
 
       - name: Verify correct version
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 env:
-  # renovate: datasource=github-releases depName=block/goose extractVersion=^v(?<version>.*)$
+  # renovate: datasource=github-releases depName=aaif-goose/goose extractVersion=^v(?<version>.*)$
   DEFAULT_GOOSE_VERSION: '1.15.0'
 
 jobs:

--- a/ASSURANCE.md
+++ b/ASSURANCE.md
@@ -4,13 +4,13 @@ This document provides the security assurance case for setup-goose-action.
 
 ## What the action does
 
-setup-goose-action is a GitHub Actions composite action that downloads a pre-built binary of the [Goose AI agent](https://github.com/block/goose) from the official GitHub Releases page, caches it using the GitHub Actions cache, and adds it to `$GITHUB_PATH`. The action does not execute Goose, does not handle API keys, and performs no AI operations itself.
+setup-goose-action is a GitHub Actions composite action that downloads a pre-built binary of the [Goose AI agent](https://github.com/aaif-goose/goose) from the official GitHub Releases page, caches it using the GitHub Actions cache, and adds it to `$GITHUB_PATH`. The action does not execute Goose, does not handle API keys, and performs no AI operations itself.
 
 ## Trust boundaries
 
 | Boundary | Direction | Description |
 |----------|-----------|-------------|
-| GitHub Releases (HTTPS) | Inbound | Goose binary downloaded from `github.com/block/goose/releases` |
+| GitHub Releases (HTTPS) | Inbound | Goose binary downloaded from `github.com/aaif-goose/goose/releases` |
 | GitHub Actions cache | Bidirectional | Cached binary stored and restored by `actions/cache` |
 | `$GITHUB_PATH` | Outbound | Binary location appended to the runner PATH |
 | Caller workflow | Inbound | `version` and `check-latest` inputs supplied by the calling workflow |
@@ -21,7 +21,7 @@ The action makes no outbound calls beyond the GitHub Releases download URL and t
 
 The primary attack surfaces are:
 
-1. **Supply chain -- upstream binary**: The Goose binary is downloaded from `github.com/block/goose/releases`. This is mitigated by using HTTPS exclusively and pinning to a caller-specified version. The `check-latest` input queries the GitHub API for the latest release tag before downloading.
+1. **Supply chain -- upstream binary**: The Goose binary is downloaded from `github.com/aaif-goose/goose/releases`. This is mitigated by using HTTPS exclusively and pinning to a caller-specified version. The `check-latest` input queries the GitHub API for the latest release tag before downloading.
 
 2. **Prompt injection in caller workflows**: Callers that pass user-controlled content (git diffs, commit messages) to Goose are vulnerable to prompt injection. This is a known risk documented in the README with three defensive tiers (see [Security Patterns](README.md#security-patterns)).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://www.bestpractices.dev/projects/11555"><img alt="OpenSSF Best Practices" src="https://img.shields.io/cii/level/11555?style=for-the-badge" height="20"></a>
 </p>
 
-<p align="center">A GitHub Action that installs and caches the <a href="https://github.com/block/goose">Goose AI agent</a> for CI/CD workflows. OpenSSF silver certified: fewer than 1% of open source projects reach this level.</p>
+<p align="center">A GitHub Action that installs and caches the <a href="https://github.com/aaif-goose/goose">Goose AI agent</a> for CI/CD workflows. OpenSSF silver certified: fewer than 1% of open source projects reach this level.</p>
 
 **Available on the [GitHub Marketplace](https://github.com/marketplace/actions/setup-goose-cli)**
 
@@ -40,7 +40,7 @@
 
 ## Prerequisites
 
-1. **Get an API key** from your chosen provider: [Supported Providers](https://block.github.io/goose/docs/getting-started/providers/)
+1. **Get an API key** from your chosen provider: [Supported Providers](https://goose-docs.ai/docs/getting-started/providers/)
 
 2. **Add it as a repository secret:**
    - Go to **Settings > Secrets and variables > Actions**
@@ -154,7 +154,7 @@ Ensure you're using the action before attempting to run `goose`:
 
 ### Unsupported version
 
-Check available versions at [Goose Releases](https://github.com/block/goose/releases). Ensure the version exists and has pre-built binaries.
+Check available versions at [Goose Releases](https://github.com/aaif-goose/goose/releases). Ensure the version exists and has pre-built binaries.
 
 ## Contributing
 
@@ -167,8 +167,8 @@ Apache 2.0. See [LICENSE](LICENSE).
 ## Related
 
 - [AI-Augmented CI/CD](https://clouatre.ca/posts/ai-augmented-cicd/): 3-tier security model for AI code review in CI/CD pipelines
-- [Goose](https://github.com/block/goose): Official Goose repository
-- [Goose Documentation](https://block.github.io/goose/)
+- [Goose](https://github.com/aaif-goose/goose): Official Goose repository
+- [Goose Documentation](https://goose-docs.ai/)
 - [GitHub Actions Documentation](https://docs.github.com/en/actions)
 - [Setup Kiro Action](https://github.com/clouatre-labs/setup-kiro-action): Similar action for Kiro CLI (AWS-native, SIGV4 auth)
 - [Setup Q CLI Action](https://github.com/clouatre-labs/setup-q-cli-action): Similar action for Amazon Q Developer CLI

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ This policy covers **this GitHub Action only**.
 
 ### Out of Scope
 
-- **Goose CLI vulnerabilities** - Report to [block/goose security](https://github.com/block/goose/security)
+- **Goose CLI vulnerabilities** - Report to [aaif-goose/goose security](https://github.com/aaif-goose/goose/security)
 - **Workflow security patterns** - See [examples/](examples/) for defensive CI/CD architectures
 - **Prompt injection in AI workflows** - This is a known risk documented in the README. See [Security Patterns](README.md#security-patterns) for mitigation strategies.
 
@@ -47,7 +47,7 @@ This policy covers **this GitHub Action only**.
 
 This action:
 - OpenSSF Best Practices **Silver** certified — fewer than 1% of open source projects reach this level ([badge](https://www.bestpractices.dev/projects/11555))
-- Downloads binaries only from official [block/goose releases](https://github.com/block/goose/releases)
+- Downloads binaries only from official [aaif-goose/goose releases](https://github.com/aaif-goose/goose/releases)
 - Uses GitHub Actions cache with version-specific keys
 - Requires minimal permissions (`contents: read`)
 - Does not store or transmit API keys (user-managed via secrets)

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
           echo "::group::Checking for latest Goose version"
           
           # Query GitHub API for latest release using gh CLI
-          LATEST_TAG=$(gh api repos/block/goose/releases/latest --jq .tag_name)
+          LATEST_TAG=$(gh api repos/aaif-goose/goose/releases/latest --jq .tag_name)
           
           if [ $? -ne 0 ]; then
             echo "::error::Failed to query GitHub API for latest release"
@@ -122,8 +122,8 @@ runs:
         TEMP_DIR=$(mktemp -d)
         trap 'rm -rf "$TEMP_DIR"' EXIT
         echo "Downloading $ARCHIVE"
-        gh release download "v${VERSION}" -R block/goose --pattern "${ARCHIVE}" -D "$TEMP_DIR"
-        gh attestation verify "$TEMP_DIR/${ARCHIVE}" -R block/goose
+        gh release download "v${VERSION}" -R aaif-goose/goose --pattern "${ARCHIVE}" -D "$TEMP_DIR"
+        gh attestation verify "$TEMP_DIR/${ARCHIVE}" -R aaif-goose/goose
         tar -xj -C ~/.local/bin -f "$TEMP_DIR/${ARCHIVE}"
 
         echo "::endgroup::"

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
       "matchStrings": [
         "default:\\s*['\"](?<currentValue>\\d+\\.\\d+\\.\\d+)['\"]"
       ],
-      "depNameTemplate": "block/goose",
+      "depNameTemplate": "aaif-goose/goose",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"
     }


### PR DESCRIPTION
## Summary

Replace all stale `block/goose` references following the upstream repo transfer to `aaif-goose/goose`. The Goose docs site also moved from `block.github.io/goose` to `goose-docs.ai`. Additionally, GitHub attestations are repo-scoped and are not transferred when a repo moves -- versions released before the transfer have no attestation record under `aaif-goose/goose`, so test-pinned versions are bumped to v1.30.0, the earliest version with an attestation registered under the new org.

## Changes

**Functional (CI fix):**
- `action.yml` -- `gh api`, `gh release download`, and `gh attestation verify` calls updated to `-R aaif-goose/goose`; fixes 404 on attestation verify which was breaking all CI runs
- `.github/workflows/test.yml` -- Renovate datasource comment updated to `depName=aaif-goose/goose`; pinned test versions bumped from pre-transfer releases (1.15.0, 1.11.0) to 1.30.0, the first version with an attestation under `aaif-goose/goose`

**Documentation:**
- `README.md` -- 3 repo links updated; 2 docs links updated to `goose-docs.ai` (old `block.github.io/goose` URLs return 404)
- `ASSURANCE.md` -- 3 repo links updated
- `SECURITY.md` -- 2 repo links + link display text updated
- `renovate.json` -- `depNameTemplate` updated to `aaif-goose/goose`

## Test plan

- [ ] Tests pass: `gh attestation verify -R aaif-goose/goose` resolves correctly for v1.30.0+
- [ ] Linter clean
- [ ] Renovate auto-updates will now track the correct upstream
