### PR TITLE
chore(ci): switch to ARM64 runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,9 @@ env:
 
 jobs:
   test-ubuntu:
-    name: Test on Ubuntu
+    name: Test on Ubuntu ARM64
     if: github.event_name == 'push' || github.event.pull_request.draft == false
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -51,7 +51,7 @@ jobs:
   test-cache-install:
     name: Test caching (install)
     if: github.event_name == 'push' || github.event.pull_request.draft == false
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -75,7 +75,7 @@ jobs:
     name: Test caching (restore)
     needs: test-cache-install
     if: github.event_name == 'push' || github.event.pull_request.draft == false
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -100,7 +100,7 @@ jobs:
   test-version:
     name: Test different version
     if: github.event_name == 'push' || github.event.pull_request.draft == false
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -118,7 +118,7 @@ jobs:
   test-check-latest:
     name: Test check-latest input
     if: github.event_name == 'push' || github.event.pull_request.draft == false
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -146,7 +146,7 @@ jobs:
 
   zizmor:
     name: zizmor
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
     steps:
@@ -159,7 +159,7 @@ jobs:
 
   ci-result:
     name: CI Result
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     if: always()
     needs: [test-ubuntu, test-cache-install, test-cache-restore, test-version, test-check-latest, zizmor]
     permissions: {}


### PR DESCRIPTION
## Summary

Switch all CI runners from `ubuntu-24.04` to `ubuntu-24.04-arm` (ARM64).

## Why it works

Both tools publish `aarch64-linux` binaries and the action already detects `runner.arch` at install time, mapping `ARM64` -> `aarch64`. The musl variant (kiro only) also has an ARM64 build. No action.yml changes required.

## Changes

- `.github/workflows/test.yml`: replace `ubuntu-24.04` with `ubuntu-24.04-arm` across all jobs
- Rename job/label from "x64" to "ARM64" for accuracy

## Test plan

- [ ] All test jobs pass on ARM64 runners
- [ ] Cache key includes `runner.arch` so x64 and arm64 caches don't collide (already the case)
