### PR TITLE
chore: bump goose default to 1.34.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ permissions:
 
 env:
   # renovate: datasource=github-releases depName=aaif-goose/goose extractVersion=^v(?<version>.*)$
-  DEFAULT_GOOSE_VERSION: '1.30.0'
+  DEFAULT_GOOSE_VERSION: '1.34.0'
 
 jobs:
   test-ubuntu:
@@ -108,7 +108,7 @@ jobs:
       - name: Test older version
         uses: ./
         with:
-          version: '1.30.0'
+          version: '1.33.1'
 
       - name: Verify correct version
         run: |

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   version:
     description: 'Version of Goose to install. Examples: 1.19.1, 1.15.0. Defaults to latest stable if unset. Ignored when check-latest is true.'
     required: false
-    default: '1.33.1'
+    default: '1.34.0'
   check-latest:
     description: 'Fetch and install the absolute latest Goose release from GitHub. When true, the version input is ignored.'
     required: false


### PR DESCRIPTION
## Summary

Bumps the default Goose version from 1.33.1 to 1.34.0 and the test workflow's pinned version from 1.30.0 to 1.34.0.

## Changes

- `action.yml`: default version 1.33.1 -> 1.34.0
- `.github/workflows/test.yml`: DEFAULT_GOOSE_VERSION and test-version hardcode 1.30.0 -> 1.34.0

## Validation

- All GitHub Action SHAs (actions/checkout v6.0.2, actions/cache v5.0.5, zizmor-action v0.5.3) confirmed at latest.
- Goose 1.34.0 ARM64 binary confirmed available at `aaif-goose/goose` release.
