### PR TITLE
ci: add pr-review workflow and instructions

### DIFF
--- a/.github/instructions/pr-review.md
+++ b/.github/instructions/pr-review.md
@@ -1,0 +1,30 @@
+# PR Review Instructions
+
+## Scope
+
+Review only what the PR changes. Do not flag issues in files the PR does not touch.
+
+## Workflow files
+
+When reviewing `.github/workflows/` changes:
+
+- Evaluate the full job context, not individual steps in isolation. A step that installs a binary
+  and a step that executes it are part of the same job; verify both exist before flagging a
+  missing publish or execution command.
+- Flag `${{ expression }}` interpolation directly inside `run:` scripts as an injection risk;
+  inputs should be passed via `env:` blocks.
+- Verify action pins use commit SHAs, not mutable tags.
+- Check that `permissions:` blocks are present and minimal.
+
+## action.yml / composite actions
+
+- Verify new inputs have a `description` field.
+- Do not flag missing `default:` on required inputs; required inputs have no default by design.
+
+## General
+
+- One comment per distinct issue; do not duplicate findings across multiple inline comments.
+- Prefer suggesting a fix (suggestion block) over describing the problem when the fix is
+  unambiguous.
+- Do not comment on code style that linters or formatters catch automatically; those are enforced
+  by CI.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,34 @@
+name: Review Pull Requests
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  review:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Review PR
+        uses: clouatre-labs/aptu@cb08760ef7f38176359a4b1713297cced31b76f5 # v0.7.0
+        continue-on-error: true
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
+          openrouter-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          provider: gemini
+          model: gemini-3.1-flash-lite-preview
+          fallback-provider: openrouter
+          fallback-model: inception/mercury-2
+          instructions-file: .github/instructions/pr-review.md
+          repo-path: ${{ github.workspace }}


### PR DESCRIPTION
Add `.github/instructions/pr-review.md` and `.github/workflows/pr-review.yml` to enable aptu AI PR review on every pull request.
