### PR TITLE
chore(ci): pin aptu action to v0.8.2

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Review PR
-        uses: clouatre-labs/aptu@475e47a210fc7c10bf9a5a4d453c0eeb0e97f9fc # v0.8.1
+        uses: clouatre-labs/aptu@8c21f970ddc71cb2955a3434d594cc4a7f27830c # v0.8.2
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pin `clouatre-labs/aptu` to the v0.8.2 release SHA (`8c21f970ddc71cb2955a3434d594cc4a7f27830c`).

Closes no issue. Routine action pin update following the v0.8.2 release.
